### PR TITLE
put back in the dynamic sizing of scratch but added a max width

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,9 +51,11 @@
                 <div id="git-hub">
                     <h3 tabindex="0" class="heading">Examples of work</h3>
 
-                    <iframe src="https://scratch.mit.edu/projects/452715548/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
+                    <iframe id="scratch" src="https://scratch.mit.edu/projects/452715548/embed" allowtransparency="true" frameborder="0" scrolling="no" allowfullscreen></iframe>
 
-                    <img id="avatar" src="https://i.imgur.com/VdxLxL3.png" alt="Saras avatar">
+                    <div>
+                      <img id="avatar" src="https://i.imgur.com/VdxLxL3.png" alt="Saras avatar">
+                    </div>
 
                     <p> More examples of my work can be found on <a href="link to git hub">Github</a> </p>
                 </div>

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ body {
     color:#333 ;
 }
 
-/* #scratch { /*doesn't work with bigger screen 
+/* #scratch { /*doesn't work with bigger screen
     width: 80vw;
     height: 60vw;
 }   */
@@ -148,6 +148,14 @@ blockquote {
 
 #git-hub {
     text-align: center;
+    clear: both;
+}
+
+#scratch {
+    width: 75vw;
+    height: 60vw;
+    max-width: 480px;
+    max-height: 384px;
 }
 
 #contact {
@@ -164,7 +172,7 @@ blockquote {
     margin: 0, 0, 20px, 0;
     font-family:'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
     padding: 5px 20px 20px 20px;
-    
+
 }
 
 .contact-link {
@@ -223,9 +231,9 @@ blockquote {
   }
 
   p {
-    font-size: 95%; 
+    font-size: 95%;
   }
-  
+
   h4 {
     font-size: 38px;
     }
@@ -242,7 +250,7 @@ blockquote {
   }
 
   p {
-    font-size: 90%; 
+    font-size: 90%;
   }
 
   .contact-link {
@@ -259,7 +267,7 @@ blockquote {
   }
 
   p {
-    font-size: 85%; 
+    font-size: 85%;
   }
 
   @media all and (max-width:280px) {
@@ -272,11 +280,11 @@ blockquote {
         font-size: 59%;
         font-weight: bold;
       }
-   
+
   }
 
   p {
-    font-size: 80%; 
+    font-size: 80%;
   }
 
 @media all and (max-width:200px) {


### PR DESCRIPTION
Might need to tweak the percentages a little bit but this is a lot better than it currently is. I have checked on desktop and mobile.

This PR also pushes the "Examples of other work" below the floated image using `clear: both;`. You can ask me about this tomorrow. If this is not your desire then simply remove the `clear: both;` line.